### PR TITLE
TYPO: Broken cross-reference in Chapter 'Basic operations'

### DIFF
--- a/src/DataTypes.qmd
+++ b/src/DataTypes.qmd
@@ -478,7 +478,7 @@ a
 a[1] <- NULL
 ```
 
-However, in lists, and therefore also data frames (see @dataframestruc), replacing an 
+However, in lists, and therefore also data frames (see #dataframestruc), replacing an 
 element with `NULL` ***removes that element***:
 
 ```{r}


### PR DESCRIPTION
TYPO: Fixes broken cross-reference in <https://class.lambdamd.org/pdsr/DataTypes.html#replacing-with-null> that `quarto render` also complains about ("[WARNING] Citeproc: citation dataframestruc not found")